### PR TITLE
docs: fit transform addition

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -71,6 +71,8 @@ The following methods, dispatched on model type, are provided:
 - `fit`, for regular training, overloaded if the model generalizes to new data, as in
   classical supervised learning; the principal output of `fit` is the learned parameters
 
+- `fit_transform`, for training transformations and transforming data in a single function call (specially usefull to avoid iterating over the data several times).
+
 - `update!`, for adding model iterations, or responding efficiently to other
   post-`fit`changes in hyperparameters
 


### PR DESCRIPTION
I am missing a method that might allow fitting a transformation and returning the transformed result in a single call.

Here there is an  example from sklearn that shows the usage of `fit_transform`

```python
>>> from sklearn.feature_extraction.text import CountVectorizer
>>> corpus = [
...     'This is the first document.',
...     'This document is the second document.',
...     'And this is the third one.',
...     'Is this the first document?',
... ]
>>> vectorizer = CountVectorizer()
>>> X = vectorizer.fit_transform(corpus)
>>> vectorizer.get_feature_names_out()
array(['and', 'document', 'first', 'is', 'one', 'second', 'the', 'third',
       'this'], ...)
>>> print(X.toarray())
[[0 1 1 1 0 0 1 0 1]
 [0 2 0 1 0 1 1 0 1]
 [1 0 0 1 1 0 1 1 1]
 [0 1 1 1 0 0 1 0 1]]
```

Note that you could just think that  `fit_transform` simply has `fit` and `transform` inside as two function calls, but this would require iterating over the data twice (one for each function call).  

One benefit of `fit_transform`  is that it can iterate only once over the data and generate the transformed data while it is iterating  over it. 

If no specific efficient `fit_transform`   is implemented it could be just sintactic sugar for calling `fit!(transformer, X)` and then `transform(transformer, X)`