### PR TITLE
Use "learner" instead of "algorithm" in docs and in variable names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,6 @@ uuid = "92ad9a40-7767-427a-9ee6-6e577f1266cb"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 version = "0.1.0"
 
-[deps]
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
 [compat]
 julia = "1.6"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,7 @@ makedocs(
             "target/weights/features" => "target_weights_features.md",
             "obs" => "obs.md",
             "Accessor Functions" => "accessor_functions.md",
-            "Algorithm Traits" => "traits.md",
+            "Learner Traits" => "traits.md",
         ],
         "Common Implementation Patterns" => "common_implementation_patterns.md",
         "Testing an Implementation" => "testing_an_implementation.md",

--- a/docs/src/accessor_functions.md
+++ b/docs/src/accessor_functions.md
@@ -1,10 +1,10 @@
 # [Accessor Functions](@id accessor_functions)
 
 The sole argument of an accessor function is the output, `model`, of
-[`fit`](@ref). Algorithms are free to implement any number of these, or none of them. Only
+[`fit`](@ref). Learners are free to implement any number of these, or none of them. Only
 `LearnAPI.strip` has a fallback, namely the identity.
 
-- [`LearnAPI.algorithm(model)`](@ref)
+- [`LearnAPI.learner(model)`](@ref)
 - [`LearnAPI.extras(model)`](@ref)
 - [`LearnAPI.strip(model)`](@ref)
 - [`LearnAPI.coefficients(model)`](@ref)
@@ -18,12 +18,12 @@ The sole argument of an accessor function is the output, `model`, of
 - [`LearnAPI.training_scores(model)`](@ref)
 - [`LearnAPI.components(model)`](@ref)
 
-Algorithm-specific accessor functions may also be implemented. The names of all accessor
-functions are included in the list returned by [`LearnAPI.functions(algorithm)`](@ref).
+Learner-specific accessor functions may also be implemented. The names of all accessor
+functions are included in the list returned by [`LearnAPI.functions(learner)`](@ref).
 
 ## Implementation guide
 
-All new implementations must implement [`LearnAPI.algorithm`](@ref). While, all others are
+All new implementations must implement [`LearnAPI.learner`](@ref). While, all others are
 optional, any implemented accessor functions must be added to the list returned by
 [`LearnAPI.functions`](@ref).
 
@@ -31,7 +31,7 @@ optional, any implemented accessor functions must be added to the list returned 
 ## Reference
 
 ```@docs
-LearnAPI.algorithm
+LearnAPI.learner
 LearnAPI.extras
 LearnAPI.strip
 LearnAPI.coefficients

--- a/docs/src/common_implementation_patterns.md
+++ b/docs/src/common_implementation_patterns.md
@@ -1,8 +1,6 @@
 # Common Implementation Patterns
 
-!!! warning
-
-!!! warning
+!!! important
 
 	This section is only an implementation guide. The definitive specification of the
 	Learn API is given in [Reference](@ref reference).

--- a/docs/src/common_implementation_patterns.md
+++ b/docs/src/common_implementation_patterns.md
@@ -1,4 +1,4 @@
-# Common Implementation Patterns
+# [Common Implementation Patterns](@id patterns)
 
 !!! important
 

--- a/docs/src/fit_update.md
+++ b/docs/src/fit_update.md
@@ -3,12 +3,12 @@
 ### Training
 
 ```julia
-fit(algorithm, data; verbosity=1) -> model
-fit(algorithm; verbosity=1) -> static_model 
+fit(learner, data; verbosity=1) -> model
+fit(learner; verbosity=1) -> static_model 
 ```
 
 A "static" algorithm is one that does not generalize to new observations (e.g., some
-clustering algorithms); there is no trainiing data and the algorithm is executed by
+clustering algorithms); there is no training data and the algorithm is executed by
 `predict` or `transform` which receive the data. See example below.
 
 
@@ -20,17 +20,15 @@ update_observations(model, new_data; verbosity=1, param1=new_value1, ...) -> upd
 update_features(model, new_data; verbosity=1, param1=new_value1, ...) -> updated_model
 ```
 
-Data slurping forms are similarly provided for updating methods.
-
 ## Typical workflows
 
 ### Supervised models
 
-Supposing `Algorithm` is some supervised classifier type, with an iteration parameter `n`:
+Supposing `Learner` is some supervised classifier type, with an iteration parameter `n`:
 
 ```julia
-algorithm = Algorithm(n=100)
-model = fit(algorithm, (X, y))
+learner = Learner(n=100)
+model = fit(learner, (X, y))
 
 # Predict probability distributions:
 ŷ = predict(model, Distribution(), Xnew) 
@@ -47,30 +45,30 @@ See also [Classification](@ref) and [Regression](@ref).
 
 ### Transformers
 
-A dimension-reducing transformer, `algorithm`  might be used in this way:
+A dimension-reducing transformer, `learner`  might be used in this way:
 
 ```julia
-model = fit(algorithm, X)
+model = fit(learner, X)
 transform(model, X) # or `transform(model, Xnew)`
 ```
 
 or, if implemented, using a single call:
 
 ```julia
-transform(algorithm, X) # `fit` implied
+transform(learner, X) # `fit` implied
 ```
 
 ### [Static algorithms (no "learning")](@id static_algorithms)
 
-Suppose `algorithm` is some clustering algorithm that cannot be generalized to new data
+Suppose `learner` is some clustering algorithm that cannot be generalized to new data
 (e.g. DBSCAN):
 
 ```julia
-model = fit(algorithm) # no training data
+model = fit(learner) # no training data
 labels = predict(model, X) # may mutate `model`
 
 # Or, in one line:
-labels = predict(algorithm, X)
+labels = predict(learner, X)
 
 # But two-line version exposes byproducts of the clustering algorithm (e.g., outliers):
 LearnAPI.extras(model)
@@ -84,14 +82,14 @@ In density estimation, `fit` consumes no features, only a target variable; `pred
 which consumes no data, returns the learned density:
 
 ```julia
-model = fit(algorithm, y) # no features
+model = fit(learner, y) # no features
 predict(model)  # shortcut for  `predict(model, SingleDistribution())`, or similar
 ```
 
 A one-liner will typically be implemented as well:
 
 ```julia
-predict(algorithm, y)
+predict(learner, y)
 ```
 
 See also [Density Estimation](@ref).
@@ -101,10 +99,12 @@ See also [Density Estimation](@ref).
 
 ### Training
 
-| method                                                                         | fallback                                                         | compulsory?        |
-|:-------------------------------------------------------------------------------|:-----------------------------------------------------------------|--------------------|
-| [`fit`](@ref)`(algorithm, data; verbosity=1)`                                  | ignores `data` and applies signature below                       | yes, unless static |
-| [`fit`](@ref)`(algorithm; verbosity=1)`                                        | none                                                             | no, unless static  |
+Exactly one of the following must be implemented:
+
+| method                                      | fallback |
+|:--------------------------------------------|:---------|
+| [`fit`](@ref)`(learner, data; verbosity=1)` | none     |
+| [`fit`](@ref)`(learner; verbosity=1)`       | none     |
 
 ### Updating
 
@@ -114,7 +114,7 @@ See also [Density Estimation](@ref).
 | [`update_observations`](@ref)`(model, data; verbosity=1, hyperparameter_updates...)` | none     | no          |
 | [`update_features`](@ref)`(model, data; verbosity=1, hyperparameter_updates...)`     | none     | no          |
 
-There are some contracts regarding the behaviour of the update methods, as they relate to
+There are some contracts governing the behaviour of the update methods, as they relate to
 a previous `fit` call. Consult the document strings for details.
 
 ## Reference

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,9 +63,9 @@ LearnAPI.feature_importances(model)
 small_model = LearnAPI.strip(model)
 serialize("my_random_forest.jls", small_model)
 
-# Recover saved model and algorithm configuration:
+# Recover saved model and algorithm configuration ("learner"):
 recovered_model = deserialize("my_random_forest.jls")
-@assert LearnAPI.algorithm(recovered_model) == forest
+@assert LearnAPI.learner(recovered_model) == forest
 @assert predict(recovered_model, Point(), Xnew) == ŷ
 ```
 
@@ -73,7 +73,7 @@ recovered_model = deserialize("my_random_forest.jls")
 dispatch based on the [kind of target proxy](@ref proxy), a key LearnAPI.jl concept.
 LearnAPI.jl places more emphasis on the notion of target variables and target proxies than
 on the usual supervised/unsupervised learning dichotomy. From this point of view, a
-supervised algorithm is simply one in which a target variable exists, and happens to
+supervised learner is simply one in which a target variable exists, and happens to
 appear as an input to training but not to prediction.
 
 ## Data interfaces

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,11 +11,11 @@ A base Julia interface for machine learning and statistics </span>
 
 LearnAPI.jl is a lightweight, functional-style interface, providing a collection of
 [methods](@ref Methods), such as `fit` and `predict`, to be implemented by algorithms from
-machine learning and statistics. Its careful design ensures algorithms implementing
-LearnAPI.jl can buy into functionality, such as external performance estimates,
-hyperparameter optimization and model composition, provided by ML/statistics toolboxes and
-other packages. LearnAPI.jl includes a number of Julia [traits](@ref traits) for promising
-specific behavior.
+machine learning and statistics, some examples of which are listed [here](@ref
+patterns). A careful design ensures algorithms implementing LearnAPI.jl can buy into
+functionality, such as external performance estimates, hyperparameter optimization and
+model composition, provided by ML/statistics toolboxes and other packages. LearnAPI.jl
+includes a number of Julia [traits](@ref traits) for promising specific behavior.
 
 LearnAPI.jl's only dependency is the standard library `InteractiveUtils`. 
 
@@ -99,7 +99,7 @@ loaders reading images from disk).
 
 - [Reference](@ref reference): official specification
 
-- [Common Implementation Patterns](@ref): implementation suggestions for common,
+- [Common Implementation Patterns](@ref patterns): implementation suggestions for common,
   informally defined, algorithm types
 
 - [Testing an Implementation](@ref)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,7 +17,7 @@ functionality, such as external performance estimates, hyperparameter optimizati
 model composition, provided by ML/statistics toolboxes and other packages. LearnAPI.jl
 includes a number of Julia [traits](@ref traits) for promising specific behavior.
 
-LearnAPI.jl's only dependency is the standard library `InteractiveUtils`. 
+LearnAPI.jl's has no package dependencies.
 
 ```@raw html
 &#128679;

--- a/docs/src/obs.md
+++ b/docs/src/obs.md
@@ -1,38 +1,38 @@
 # [`obs` and Data Interfaces](@id data_interface)
 
 The `obs` method takes data intended as input to `fit`, `predict` or `transform`, and
-transforms it to an algorithm-specific form guaranteed to implement a form of observation
-access designated by the algorithm. The transformed data can then be resampled and passed
+transforms it to a learner-specific form guaranteed to implement a form of observation
+access designated by the learner. The transformed data can then be resampled and passed
 on to the relevant method in place of the original input. Using `obs` may provide
 performance advantages over naive workflows in some cases (e.g., cross-validation).
 
 ```julia
-obs(algorithm, data) # can be passed to `fit` instead of `data`
+obs(learner, data) # can be passed to `fit` instead of `data`
 obs(model, data)     # can be passed to `predict` or `transform` instead of `data`
 ```
 
 ## [Typical workflows](@id obs_workflows)
 
 LearnAPI.jl makes no universal assumptions about the form of `data` in a call
-like `fit(algorithm, data)`. However, if we define
+like `fit(learner, data)`. However, if we define
 
 ```julia
-observations = obs(algorithm, data)
+observations = obs(learner, data)
 ```
 
-then, assuming the typical case that `LearnAPI.data_interface(algorithm) ==
+then, assuming the typical case that `LearnAPI.data_interface(learner) ==
 LearnAPI.RandomAccess()`, `observations` implements the
 [MLUtils.jl](https://juliaml.github.io/MLUtils.jl/dev/) `getobs`/`numobs` interface, for
 grabbing and counting observations. Moreover, we can pass `observations` to `fit` in place
 of the original data, or first resample it using `MLUtils.getobs`:
 
 ```julia
-# equivalent to `model = fit(algorithm, data)`
-model = fit(algorithm, observations)
+# equivalent to `model = fit(learner, data)`
+model = fit(learner, observations)
 
 # with resampling:
 resampled_observations = MLUtils.getobs(observations, 1:10)
-model = fit(algorithm, resampled_observations)
+model = fit(learner, resampled_observations)
 ```
 
 In some implementations, the alternative pattern above can be used to avoid repeating
@@ -43,24 +43,24 @@ how a user might call `obs` and `MLUtils.getobs` to perform efficient cross-vali
 using LearnAPI
 import MLUtils
 
-algorithm = <some supervised learner>
+learner = <some supervised learner>
 
 data = <some data that `fit` can consume, with 30 observations>
-X = LearnAPI.features(algorithm, data)
-y = LearnAPI.target(algorithm, data)
+X = LearnAPI.features(learner, data)
+y = LearnAPI.target(learner, data)
 
 train_test_folds = map([1:10, 11:20, 21:30]) do test
     (setdiff(1:30, test), test)
 end
 
-fitobs = obs(algorithm, data)
+fitobs = obs(learner, data)
 never_trained = true
 
 scores = map(train_test_folds) do (train, test)
 
     # train using model-specific representation of data:
     fitobs_subset = MLUtils.getobs(fitobs, train)
-    model = fit(algorithm, fitobs_subset)
+    model = fit(learner, fitobs_subset)
 
     # predict on the fold complement:
     if never_trained
@@ -79,7 +79,7 @@ end
 
 | method                         | comment                             | compulsory?   | fallback       |
 |:-------------------------------|:------------------------------------|:-------------:|:---------------|
-| [`obs(algorithm, data)`](@ref) | here `data` is `fit`-consumable     | not typically | returns `data` |
+| [`obs(learner, data)`](@ref) | here `data` is `fit`-consumable     | not typically | returns `data` |
 | [`obs(model, data)`](@ref)     | here `data` is `predict`-consumable | not typically | returns `data` |
 
 
@@ -94,7 +94,7 @@ obs
 
 ### [Data interfaces](@id data_interfaces)
 
-New implementations must overload [`LearnAPI.data_interface(algorithm)`](@ref) if the
+New implementations must overload [`LearnAPI.data_interface(learner)`](@ref) if the
 output of [`obs`](@ref) does not implement [`LearnAPI.RandomAccess`](@ref). (Arrays, most
 tables, and all tuples thereof, implement `RandomAccess`.)
 

--- a/docs/src/predict_transform.md
+++ b/docs/src/predict_transform.md
@@ -6,15 +6,15 @@ transform(model, data)
 inverse_transform(model, data)
 ```
 
-Versions without the `data` argument may also appear, for example in [Density
+Versions without the `data` argument may apply, for example in [Density
 estimation](@ref).
 
 ## [Typical worklows](@id predict_workflow)
 
-Train some supervised `algorithm`:
+Train some supervised `learner`:
 
 ```julia
-model = fit(algorithm, (X, y))
+model = fit(learner, (X, y))
 ```
 
 Predict probability distributions:
@@ -29,10 +29,10 @@ Generate point predictions:
 ŷ = predict(model, Point(), Xnew)
 ```
 
-Train a dimension-reducing `algorithm`:
+Train a dimension-reducing `learner`:
 
 ```julia
-model = fit(algorithm, X)
+model = fit(learner, X)
 Xnew_reduced = transform(model, Xnew)
 ```
 
@@ -42,11 +42,17 @@ Apply an approximate right inverse:
 inverse_transform(model, Xnew_reduced)
 ```
 
+Fit and transform in one line:
+
+```julia
+transform(learner, data) # `fit` implied
+```
+
 ### An advanced workflow
 
 ```julia
-fitobs = obs(algorithm, (X, y)) # algorithm-specific repr. of data
-model = fit(algorithm, MLUtils.getobs(fitobs, 1:100))
+fitobs = obs(learner, (X, y)) # learner-specific repr. of data
+model = fit(learner, MLUtils.getobs(fitobs, 1:100))
 predictobs = obs(model, MLUtils.getobs(X, 101:150))
 ŷ = predict(model, Point(), predictobs)
 ```
@@ -62,37 +68,37 @@ ŷ = predict(model, Point(), predictobs)
 
 ### Predict or transform?
 
-If the algorithm has a notion of [target variable](@ref proxy), then use 
+If the learner has a notion of [target variable](@ref proxy), then use 
 [`predict`](@ref) to output each supported [kind of target proxy](@ref
 proxy_types) (`Point()`, `Distribution()`, etc).
 
 For output not associated with a target variable, implement [`transform`](@ref)
 instead, which does not dispatch on [`LearnAPI.KindOfProxy`](@ref), but can be optionally
 paired with an implementation of [`inverse_transform`](@ref), for returning (approximate)
-right inverses to `transform`.
+right or left inverses to `transform`.
 
-Of course, the one algorithm can implement both a `predict` and `transform` method. For
+Of course, the one learner can implement both a `predict` and `transform` method. For
 example a K-means clustering algorithm can `predict` labels and `transform` to reduce
 dimension using distances from the cluster centres.
 
 
 ### [One-liners combining fit and transform/predict](@id one_liners)
 
-Algorithms may optionally overload `transform` to apply `fit` first, using the supplied
+Learners may optionally overload `transform` to apply `fit` first, using the supplied
 data if required, and then immediately `transform` the same data. The same applies to
-`predict`. In that case the first argument of `transform`/`predict` is an *algorithm*
+`predict`. In that case the first argument of `transform`/`predict` is an *learner*
 instead of the output of `fit`:
 
 ```julia
-predict(algorithm, kind_of_proxy, data) # `fit` implied
-transform(algorithm, data) # `fit` implied
+predict(learner, kind_of_proxy, data) # `fit` implied
+transform(learner, data) # `fit` implied
 ```
 
-For example, if `fit(algorithm, X)` is defined, then `predict(algorithm, X)` will be
+For example, if `fit(learner, X)` is defined, then `predict(learner, X)` will be
 shorthand for
 
 ```julia
-model = fit(algorithm, X)
+model = fit(learner, X)
 predict(model, X)
 ```
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -2,7 +2,7 @@
 
 Here we give the definitive specification of the LearnAPI.jl interface. For informal
 guides see [Anatomy of an Implementation](@ref) and [Common Implementation
-Patterns](@ref).
+Patterns](@ref patterns).
 
 
 ## [Important terms and concepts](@id scope)

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -16,7 +16,7 @@ ML/statistical algorithms are typically applied in conjunction with resampling o
 *observations*, as in
 [cross-validation](https://en.wikipedia.org/wiki/Cross-validation_(statistics)). In this
 document *data* will always refer to objects encapsulating an ordered sequence of
-individual observations. If an algorithm is trained using multiple data objects, it is
+individual observations. If a learner is trained using multiple data objects, it is
 undertood that individual objects share the same number of observations, and that
 resampling of one component implies synchronized resampling of the others.
 
@@ -29,9 +29,9 @@ see [`obs`](@ref) and [`LearnAPI.data_interface`](@ref) for details.
 
 !!! note
 
-	In the MLUtils.jl
-	convention, observations in tables are the rows but observations in a matrix are the
-	columns.
+    In the MLUtils.jl
+    convention, observations in tables are the rows but observations in a matrix are the
+    columns.
 
 ### [Hyperparameters](@id hyperparameters)
 
@@ -70,67 +70,69 @@ dispatch. These are also used to distinguish performance metrics provided by the
 [StatisticalMeasures.jl](https://juliaai.github.io/StatisticalMeasures.jl/dev/).
 
 
-### [Algorithms](@id algorithms)
+### [Learners](@id learners)
 
-An object implementing the LearnAPI.jl interface is called an *algorithm*, although it is
-more accurately "the configuration of some algorithm".¹ An algorithm encapsulates a
-particular set of user-specified [hyperparameters](@ref) as the object's *properties*
-(which conceivably differ from its fields). It does not store learned parameters.
+An object implementing the LearnAPI.jl interface is called a *learner*, although it is
+more accurately "the configuration of some machine learning or statistical algorithm".¹ A
+learner encapsulates a particular set of user-specified [hyperparameters](@ref) as the
+object's *properties* (which conceivably differ from its fields). It does not store
+learned parameters.
 
 Informally, we will sometimes use the word "model" to refer to the output of
-`fit(algorithm, ...)` (see below), something which typically does store learned
+`fit(learner, ...)` (see below), something which typically does *store* learned
 parameters.
 
-For `algorithm` to be a valid LearnAPI.jl algorithm,
-[`LearnAPI.constructor(algorithm)`](@ref) must be defined and return a keyword constructor
-enabling recovery of `algorithm` from its properties:
+For `learner` to be a valid LearnAPI.jl learner,
+[`LearnAPI.constructor(learner)`](@ref) must be defined and return a keyword constructor
+enabling recovery of `learner` from its properties:
 
 ```julia
-properties = propertynames(algorithm)
-named_properties = NamedTuple{properties}(getproperty.(Ref(algorithm), properties))
-@assert algorithm == LearnAPI.constructor(algorithm)(; named_properties...)
+properties = propertynames(learner)
+named_properties = NamedTuple{properties}(getproperty.(Ref(learner), properties))
+@assert learner == LearnAPI.constructor(learner)(; named_properties...)
 ```
 
-which can be tested with `@assert `[`LearnAPI.clone(algorithm)`](@ref)` == algorithm`.
+which can be tested with `@assert `[`LearnAPI.clone(learner)`](@ref)` == learner`.
 
-Note that if if `algorithm` is an instance of a *mutable* struct, this requirement
+Note that if if `learner` is an instance of a *mutable* struct, this requirement
 generally requires overloading `Base.==` for the struct.
 
-No LearnAPI.jl method is permitted to mutate an algorithm. In particular, one should make
+No LearnAPI.jl method is permitted to mutate a learner. In particular, one should make
 deep copies of RNG hyperparameters before using them in a new implementation of
 [`fit`](@ref).
 
-#### Composite algorithms (wrappers)
+#### Composite learners (wrappers)
 
-A *composite algorithm* is one with at least one property that can take other algorithms
-as values; for such algorithms [`LearnAPI.is_composite`](@ref)`(algorithm)` must be `true`
+A *composite learner* is one with at least one property that can take other learners as
+values; for such learners [`LearnAPI.is_composite`](@ref)`(learner)` must be `true`
 (fallback is `false`). Generally, the keyword constructor provided by
 [`LearnAPI.constructor`](@ref) must provide default values for all properties that are not
-algorithm-valued. Instead, these algorithm-valued properties can have a `nothing` default,
-with the constructor throwing an error if the default value persists.
+learner-valued. Instead, these learner-valued properties can have a `nothing` default,
+with the constructor throwing an error if the the constructor call does not explicitly
+specify a new value.
 
-Any object `algorithm` for which [`LearnAPI.functions`](@ref)`(algorithm)` is non-empty is
+Any object `learner` for which [`LearnAPI.functions(learner)`](@ref) is non-empty is
 understood to have a valid implementation of the LearnAPI.jl interface.
 
 #### Example
 
-Any instance of `GradientRidgeRegressor` defined below is a valid algorithm.
+Any instance of `GradientRidgeRegressor` defined below is a valid learner.
 
 ```julia
 struct GradientRidgeRegressor{T<:Real}
-	learning_rate::T
-	epochs::Int
-	l2_regularization::T
+    learning_rate::T
+    epochs::Int
+    l2_regularization::T
 end
 GradientRidgeRegressor(; learning_rate=0.01, epochs=10, l2_regularization=0.01) =
-	GradientRidgeRegressor(learning_rate, epochs, l2_regularization)
+    GradientRidgeRegressor(learning_rate, epochs, l2_regularization)
 LearnAPI.constructor(::GradientRidgeRegressor) = GradientRidgeRegressor
 ```
 
 ## Documentation
 
-Attach public LearnAPI.jl-related documentation for an algorithm to it's *constructor*,
-rather than to the struct defining its type. In this way, an algorithm can implement
+Attach public LearnAPI.jl-related documentation for a learner to it's *constructor*,
+rather than to the struct defining its type. In this way, a learner can implement
 multiple interfaces, in addition to the LearnAPI interface, with separate document strings
 for each.
 
@@ -138,20 +140,20 @@ for each.
 
 !!! note "Compulsory methods"
 
-	All new algorithm types must implement [`fit`](@ref),
-	[`LearnAPI.algorithm`](@ref), [`LearnAPI.constructor`](@ref) and
-	[`LearnAPI.functions`](@ref).
+    All new learner types must implement [`fit`](@ref),
+    [`LearnAPI.learner`](@ref), [`LearnAPI.constructor`](@ref) and
+    [`LearnAPI.functions`](@ref).
 
-Most algorithms will also implement [`predict`](@ref) and/or [`transform`](@ref). For a
-bare minimum implementation, see the implementation of `SmallAlgorithm`
+Most learners will also implement [`predict`](@ref) and/or [`transform`](@ref). For a
+bare minimum implementation, see the implementation of `SmallLearner`
 [here](https://github.com/JuliaAI/LearnAPI.jl/blob/dev/test/traits.jl).
 
 ### List of methods
 
-- [`fit`](@ref fit): for training or updating algorithms that generalize to new data. Or,
-  for non-generalizing algorithms (see [here](@ref static_algorithms) and [Static
-  Algorithms](@ref)), for wrapping `algorithm` in a mutable struct that can be mutated by
-  `predict`/`transform` to record byproducts of those operations.
+- [`fit`](@ref fit): for (i) training or updating learners that generalize to new data; or
+  (ii) wrapping `learner` in an object that is possibly mutated by `predict`/`transform`,
+  to record byproducts of those operations, in the special case of *non-generalizing*
+  learners (called here [static algorithms](@ref static_algorithms))
 
 - [`update`](@ref fit): for updating learning outcomes after hyperparameter changes, such
   as increasing an iteration parameter.
@@ -173,18 +175,18 @@ bare minimum implementation, see the implementation of `SmallAlgorithm`
   defined.
 
 - [`obs`](@ref data_interface): method for exposing to the user
-  algorithm-specific representations of data, which are additionally guaranteed to
+  learner-specific representations of data, which are additionally guaranteed to
   implement the observation access API specified by
-  [`LearnAPI.data_interface(algorithm)`](@ref).
+  [`LearnAPI.data_interface(learner)`](@ref).
 
 - [Accessor functions](@ref accessor_functions): these include functions like
   `LearnAPI.feature_importances` and `LearnAPI.training_losses`, for extracting, from
-  training outcomes, information common to many algorithms. This includes
+  training outcomes, information common to many learners. This includes
   [`LearnAPI.strip(model)`](@ref) for replacing a learning outcome `model` with a
   serializable version that can still `predict` or `transform`.
 
-- [Algorithm traits](@ref traits): methods that promise specific algorithm behavior or
-  record general information about the algorithm. Only [`LearnAPI.constructor`](@ref) and
+- [Learner traits](@ref traits): methods that promise specific learner behavior or
+  record general information about the learner. Only [`LearnAPI.constructor`](@ref) and
   [`LearnAPI.functions`](@ref) are universally compulsory.
 
 
@@ -197,8 +199,8 @@ LearnAPI.@trait
 
 ---
 
-¹ We acknowledge users may not like this terminology, and may know "algorithm" by some
-other name, such as "strategy", "options", "hyperparameter set", "configuration", or
-"model". Consensus on this point is difficult; see, e.g.,
+¹ We acknowledge users may not like this terminology, and may know "learner" by some other
+name, such as "strategy", "options", "hyperparameter set", "configuration", "algorithm",
+or "model". Consensus on this point is difficult; see, e.g.,
 [this](https://discourse.julialang.org/t/ann-learnapi-jl-proposal-for-a-basement-level-machine-learning-api/93048/20)
 Julia Discourse discussion.

--- a/docs/src/target_weights_features.md
+++ b/docs/src/target_weights_features.md
@@ -3,25 +3,25 @@
 Methods for extracting parts of training data:
 
 ```julia
-LearnAPI.target(algorithm, data) -> <target variable>
-LearnAPI.weights(algorithm, data) -> <per-observation weights>
-LearnAPI.features(algorithm, data) -> <training "features", suitable input for `predict` or `transform`>
+LearnAPI.target(learner, data) -> <target variable>
+LearnAPI.weights(learner, data) -> <per-observation weights>
+LearnAPI.features(learner, data) -> <training "features", suitable input for `predict` or `transform`>
 ```
 
-Here `data` is something supported in a call of the form `fit(algorithm, data)`. 
+Here `data` is something supported in a call of the form `fit(learner, data)`. 
 
 # Typical workflow
 
 Not typically appearing in a general user's workflow but useful in meta-alagorithms, such
 as cross-validation (see the example in [`obs` and Data Interfaces](@ref data_interface)).
 
-Supposing `algorithm` is a supervised classifier predicting a one-dimensional vector
+Supposing `learner` is a supervised classifier predicting a one-dimensional vector
 target:
 
 ```julia
-model = fit(algorithm, data)
-X = LearnAPI.features(algorithm, data)
-y = LearnAPI.target(algorithm, data)
+model = fit(learner, data)
+X = LearnAPI.features(learner, data)
+y = LearnAPI.target(learner, data)
 ŷ = predict(model, Point(), X)
 training_loss = sum(ŷ .!= y)
 ```

--- a/docs/src/traits.md
+++ b/docs/src/traits.md
@@ -1,9 +1,9 @@
-# [Algorithm Traits](@id traits)
+# [Learner Traits](@id traits)
 
-Algorithm traits are simply functions whose sole argument is an algorithm.
+Learner traits are simply functions whose sole argument is a learner.
 
-Traits promise specific algorithm behavior, such as: *This algorithm can make point or
-probabilistic predictions* or *This algorithm is supervised* (sees a target in
+Traits promise specific learner behavior, such as: *This learner can make point or
+probabilistic predictions* or *This learner is supervised* (sees a target in
 training). They may also record more mundane information, such as a package license.
 
 ## [Trait summary](@id trait_summary)
@@ -15,46 +15,46 @@ In the examples column of the table below, `Continuous` is a name owned the pack
 
 | trait                                                      | return value                                                                                                             | fallback value                                        | example                                                    |
 |:-----------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------|:-----------------------------------------------------------|
-| [`LearnAPI.constructor`](@ref)`(algorithm)`                | constructor for generating new or modified versions of `algorithm`                                                       | (no fallback)                                         | `RidgeRegressor`                                           |
-| [`LearnAPI.functions`](@ref)`(algorithm)`                  | functions you can apply to `algorithm` or associated model (traits excluded)                                             | `()`                                                  | `(:fit, :predict, :LearnAPI.strip, :(LearnAPI.algorithm), :obs)` |
-| [`LearnAPI.kinds_of_proxy`](@ref)`(algorithm)`             | instances `kind` of `KindOfProxy` for which an implementation of `LearnAPI.predict(algorithm, kind, ...)` is guaranteed. | `()`                                                  | `(Distribution(), Interval())`                             |
-| [`LearnAPI.tags`](@ref)`(algorithm)`                       | lists one or more suggestive algorithm tags from `LearnAPI.tags()`                                                       | `()`                                                  | (:regression, :probabilistic)                              |
-| [`LearnAPI.is_pure_julia`](@ref)`(algorithm)`              | `true` if implementation is 100% Julia code                                                                              | `false`                                               | `true`                                                     |
-| [`LearnAPI.pkg_name`](@ref)`(algorithm)`                   | name of package providing core code (may be different from package providing LearnAPI.jl implementation)                 | `"unknown"`                                           | `"DecisionTree"`                                           |
-| [`LearnAPI.pkg_license`](@ref)`(algorithm)`                | name of license of package providing core code                                                                           | `"unknown"`                                           | `"MIT"`                                                    |
-| [`LearnAPI.doc_url`](@ref)`(algorithm)`                    | url providing documentation of the core code                                                                             | `"unknown"`                                           | `"https://en.wikipedia.org/wiki/Decision_tree_learning"`   |
-| [`LearnAPI.load_path`](@ref)`(algorithm)`                  | string locating name returned by `LearnAPI.constructor(algorithm)`, beginning with a package name                        | "unknown"`                                            | `FastTrees.LearnAPI.DecisionTreeClassifier`                |
-| [`LearnAPI.is_composite`](@ref)`(algorithm)`               | `true` if one or more properties of `algorithm` may be an algorithm                                                      | `false`                                               | `true`                                                     |
-| [`LearnAPI.human_name`](@ref)`(algorithm)`                 | human name for the algorithm; should be a noun                                                                           | type name with spaces                                 | "elastic net regressor"                                    |
-| [`LearnAPI.iteration_parameter`](@ref)`(algorithm)`        | symbolic name of an iteration parameter                                                                                  | `nothing`                                             | :epochs                                                    |
-| [`LearnAPI.data_interface`](@ref)`(algorithm)`             | Interface implemented by objects returned by [`obs`](@ref)                                                               | `Base.HasLength()` (supports `MLUtils.getobs/numobs`) | `Base.SizeUnknown()` (supports `iterate`)                  |
-| [`LearnAPI.fit_observation_scitype`](@ref)`(algorithm)`    | upper bound on `scitype(observation)` for `observation` in `data` ensuring `fit(algorithm, data)` works                  | `Union{}`                                             | `Tuple{AbstractVector{Continuous}, Continuous}`            |
-| [`LearnAPI.target_observation_scitype`](@ref)`(algorithm)` | upper bound on the scitype of each observation of the targget                                                            | `Any`                                                 | `Continuous`                                               |
-| [`LearnAPI.is_static`](@ref)`(algorithm)`                  | `true` if `fit` consumes no data                                                                                         | `false`                                               | `true`                                                     |
+| [`LearnAPI.constructor`](@ref)`(learner)`                | constructor for generating new or modified versions of `learner`                                                       | (no fallback)                                         | `RidgeRegressor`                                           |
+| [`LearnAPI.functions`](@ref)`(learner)`                  | functions you can apply to `learner` or associated model (traits excluded)                                             | `()`                                                  | `(:fit, :predict, :LearnAPI.strip, :(LearnAPI.learner), :obs)` |
+| [`LearnAPI.kinds_of_proxy`](@ref)`(learner)`             | instances `kind` of `KindOfProxy` for which an implementation of `LearnAPI.predict(learner, kind, ...)` is guaranteed. | `()`                                                  | `(Distribution(), Interval())`                             |
+| [`LearnAPI.tags`](@ref)`(learner)`                       | lists one or more suggestive learner tags from `LearnAPI.tags()`                                                       | `()`                                                  | (:regression, :probabilistic)                              |
+| [`LearnAPI.is_pure_julia`](@ref)`(learner)`              | `true` if implementation is 100% Julia code                                                                              | `false`                                               | `true`                                                     |
+| [`LearnAPI.pkg_name`](@ref)`(learner)`                   | name of package providing core code (may be different from package providing LearnAPI.jl implementation)                 | `"unknown"`                                           | `"DecisionTree"`                                           |
+| [`LearnAPI.pkg_license`](@ref)`(learner)`                | name of license of package providing core code                                                                           | `"unknown"`                                           | `"MIT"`                                                    |
+| [`LearnAPI.doc_url`](@ref)`(learner)`                    | url providing documentation of the core code                                                                             | `"unknown"`                                           | `"https://en.wikipedia.org/wiki/Decision_tree_learning"`   |
+| [`LearnAPI.load_path`](@ref)`(learner)`                  | string locating name returned by `LearnAPI.constructor(learner)`, beginning with a package name                        | "unknown"`                                            | `FastTrees.LearnAPI.DecisionTreeClassifier`                |
+| [`LearnAPI.is_composite`](@ref)`(learner)`               | `true` if one or more properties of `learner` may be a learner                                                      | `false`                                               | `true`                                                     |
+| [`LearnAPI.human_name`](@ref)`(learner)`                 | human name for the learner; should be a noun                                                                           | type name with spaces                                 | "elastic net regressor"                                    |
+| [`LearnAPI.iteration_parameter`](@ref)`(learner)`        | symbolic name of an iteration parameter                                                                                  | `nothing`                                             | :epochs                                                    |
+| [`LearnAPI.data_interface`](@ref)`(learner)`             | Interface implemented by objects returned by [`obs`](@ref)                                                               | `Base.HasLength()` (supports `MLUtils.getobs/numobs`) | `Base.SizeUnknown()` (supports `iterate`)                  |
+| [`LearnAPI.fit_observation_scitype`](@ref)`(learner)`    | upper bound on `scitype(observation)` for `observation` in `data` ensuring `fit(learner, data)` works                  | `Union{}`                                             | `Tuple{AbstractVector{Continuous}, Continuous}`            |
+| [`LearnAPI.target_observation_scitype`](@ref)`(learner)` | upper bound on the scitype of each observation of the targget                                                            | `Any`                                                 | `Continuous`                                               |
+| [`LearnAPI.is_static`](@ref)`(learner)`                  | `true` if `fit` consumes no data                                                                                         | `false`                                               | `true`                                                     |
 
 ### Derived Traits
 
-The following are provided for convenience but should not be overloaded by new algorithms:
+The following are provided for convenience but should not be overloaded by new learners:
 
 | trait                              | return value                                                             | example |
 |:-----------------------------------|:-------------------------------------------------------------------------|:--------|
-| `LearnAPI.name(algorithm)`         | algorithm type name as string                                            | "PCA"   |
-| `LearnAPI.is_algorithm(algorithm)` | `true` if `algorithm` is LearnAPI.jl-compliant                           | `true`  |
-| `LearnAPI.target(algorithm)`       | `true` if `fit` sees a target variable; see [`LearnAPI.target`](@ref)    | `false` |
-| `LearnAPI.weights(algorithm)`      | `true` if `fit` supports per-observation; see [`LearnAPI.weights`](@ref) | `false` |
+| `LearnAPI.name(learner)`         | learner type name as string                                            | "PCA"   |
+| `LearnAPI.is_learner(learner)` | `true` if `learner` is LearnAPI.jl-compliant                           | `true`  |
+| `LearnAPI.target(learner)`       | `true` if `fit` sees a target variable; see [`LearnAPI.target`](@ref)    | `false` |
+| `LearnAPI.weights(learner)`      | `true` if `fit` supports per-observation; see [`LearnAPI.weights`](@ref) | `false` |
 
 ## Implementation guide
 
 A single-argument trait is declared following this pattern:
 
 ```julia
-LearnAPI.is_pure_julia(algorithm::MyAlgorithmType) = true
+LearnAPI.is_pure_julia(learner::MyLearnerType) = true
 ```
 
 A shorthand for single-argument traits is available:
 
 ```julia
-@trait MyAlgorithmType is_pure_julia=true
+@trait MyLearnerType is_pure_julia=true
 ```
 
 Multiple traits can be declared like this:
@@ -62,7 +62,7 @@ Multiple traits can be declared like this:
 
 ```julia
 @trait(
-    MyAlgorithmType,
+    MyLearnerType,
     is_pure_julia = true,
     pkg_name = "MyPackage",
 )
@@ -70,20 +70,20 @@ Multiple traits can be declared like this:
 
 ### [The global trait contract](@id trait_contract)
 
-To ensure that trait metadata can be stored in an external algorithm registry, LearnAPI.jl
+To ensure that trait metadata can be stored in an external learner registry, LearnAPI.jl
 requires:
 
-1. *Finiteness:* The value of a trait is the same for all `algorithm`s with same value of
-   [`LearnAPI.constructor(algorithm)`](@ref). This typically means trait values do not
-   depend on type parameters! If `is_composite(algorithm) = true`, this requirement is
+1. *Finiteness:* The value of a trait is the same for all `learner`s with same value of
+   [`LearnAPI.constructor(learner)`](@ref). This typically means trait values do not
+   depend on type parameters! If `is_composite(learner) = true`, this requirement is
    dropped.
 
 2. *Low level deserializability:* It should be possible to evaluate the trait *value* when
    `LearnAPI` is the only imported module. 
 
-Because of 1, combining a lot of functionality into one algorithm (e.g. the algorithm can
+Because of 1, combining a lot of functionality into one learner (e.g. the learner can
 perform both classification or regression) can mean traits are necessarily less
-informative (as in `LearnAPI.target_observation_scitype(algorithm) = Any`).
+informative (as in `LearnAPI.target_observation_scitype(learner) = Any`).
 
 
 ## Reference

--- a/src/LearnAPI.jl
+++ b/src/LearnAPI.jl
@@ -1,7 +1,5 @@
 module LearnAPI
 
-import InteractiveUtils.subtypes
-
 include("tools.jl")
 include("types.jl")
 include("predict_transform.jl")
@@ -16,7 +14,7 @@ export @trait
 export fit, update, update_observations, update_features
 export predict, transform, inverse_transform, obs
 
-for name in Symbol.(CONCRETE_TARGET_PROXY_TYPES_SYMBOLS)
+for name in CONCRETE_TARGET_PROXY_SYMBOLS
     @eval export $name
 end
 

--- a/src/clone.jl
+++ b/src/clone.jl
@@ -1,23 +1,23 @@
 """
-    LearnAPI.clone(algorithm; replacements...)
+    LearnAPI.clone(learner; replacements...)
 
-Return a shallow copy of `algorithm` with the specified hyperparameter replacements.
+Return a shallow copy of `learner` with the specified hyperparameter replacements.
 
 ```julia
-clone(algorithm; epochs=100, learning_rate=0.01)
+clone(learner; epochs=100, learning_rate=0.01)
 ```
 
-It is guaranteed that `LearnAPI.clone(algorithm) == algorithm`.
+It is guaranteed that `LearnAPI.clone(learner) == learner`.
 
 """
-function clone(algorithm; replacements...)
+function clone(learner; replacements...)
     reps = NamedTuple(replacements)
-    names = propertynames(algorithm)
+    names = propertynames(learner)
     rep_names = keys(reps)
 
     new_values = map(names) do name
         name in rep_names && return getproperty(reps, name)
-        getproperty(algorithm, name)
+        getproperty(learner, name)
     end
-    return LearnAPI.constructor(algorithm)(NamedTuple{names}(new_values)...)
+    return LearnAPI.constructor(learner)(NamedTuple{names}(new_values)...)
 end

--- a/src/fit_update.jl
+++ b/src/fit_update.jl
@@ -1,22 +1,23 @@
 # # FIT
 
 """
-    fit(algorithm, data; verbosity=1)
-    fit(algorithm; verbosity=1)
+    fit(learner, data; verbosity=1)
+    fit(learner; verbosity=1)
 
-Execute the algorithm with configuration `algorithm` using the provided training `data`,
-returning an object, `model`, on which other methods, such as [`predict`](@ref) or
-[`transform`](@ref), can be dispatched.  [`LearnAPI.functions(algorithm)`](@ref) returns a
-list of methods that can be applied to either `algorithm` or `model`.
+Execute the machine learning or statistical algorithm with configuration `learner` using
+the provided training `data`, returning an object, `model`, on which other methods, such
+as [`predict`](@ref) or [`transform`](@ref), can be dispatched.
+[`LearnAPI.functions(learner)`](@ref) returns a list of methods that can be applied to
+either `learner` or `model`.
 
 For example, a supervised classifier might have a workflow like this:
 
 ```julia
-model = fit(algorithm, (X, y))
+model = fit(learner, (X, y))
 ŷ = predict(model, Xnew)
 ```
 
-The second signature, with `data` omitted, is provided by algorithms that do not
+The second signature, with `data` omitted, is provided by learners that do not
 generalize to new observations (called *static algorithms*). In that case,
 `transform(model, data)` or `predict(model, ..., data)` carries out the actual algorithm
 execution, writing any byproducts of that operation to the mutable object `model` returned
@@ -31,7 +32,7 @@ See also [`predict`](@ref), [`transform`](@ref), [`inverse_transform`](@ref),
 
 # New implementations
 
-Implementation of exactly one of the signatures is compulsory. If `fit(algorithm;
+Implementation of exactly one of the signatures is compulsory. If `fit(learner;
 verbosity=1)` is implemented, then the trait [`LearnAPI.is_static`](@ref) must be
 overloaded to return `true`.
 
@@ -45,9 +46,9 @@ these methods. A fallback returns `first(data)` if `data` is a tuple, and `data`
 otherwise.
 
 The LearnAPI.jl specification has nothing to say regarding `fit` signatures with more than
-two arguments. For convenience, for example, an algorithm is free to implement a slurping
-signature, such as `fit(algorithm, X, y, extras...) = fit(algorithm, (X, y, extras...))` but
-LearnAPI.jl does not guarantee such signatures are actually implemented.
+two arguments. For convenience, for example, an implementation is free to implement a
+slurping signature, such as `fit(learner, X, y, extras...) = fit(learner, (X, y,
+extras...))` but LearnAPI.jl does not guarantee such signatures are actually implemented.
 
 $(DOC_DATA_INTERFACE(:fit))
 
@@ -65,10 +66,10 @@ Return an updated version of the `model` object returned by a previous [`fit`](@
 p2=value2, ...`.
 
 ```julia
-algorithm = MyForest(ntrees=100)
+learner = MyForest(ntrees=100)
 
 # train with 100 trees:
-model = fit(algorithm, data)
+model = fit(learner, data)
 
 # add 50 more trees:
 model = update(model, data; ntrees=150)
@@ -76,13 +77,13 @@ model = update(model, data; ntrees=150)
 
 Provided that `data` is identical with the data presented in a preceding `fit` call *and*
 there is at most one hyperparameter replacement, as in the above example, execution is
-semantically equivalent to the call `fit(algorithm, data)`, where `algorithm` is
-`LearnAPI.algorithm(model)` with the specified replacements. In some cases (typically,
+semantically equivalent to the call `fit(learner, data)`, where `learner` is
+`LearnAPI.learner(model)` with the specified replacements. In some cases (typically,
 when changing an iteration parameter) there may be a performance benefit to using `update`
 instead of retraining ab initio.
 
 If `data` differs from that in the preceding `fit` or `update` call, or there is more than
-one hyperparameter replacement, then behaviour is algorithm-specific.
+one hyperparameter replacement, then behaviour is learner-specific.
 
 See also [`fit`](@ref), [`update_observations`](@ref), [`update_features`](@ref).
 
@@ -104,19 +105,19 @@ Return an updated version of the `model` object returned by a previous [`fit`](@
 specify hyperparameter replacements in the form `p1=value1, p2=value2, ...`.
 
 ```julia-repl
-algorithm = MyNeuralNetwork(epochs=10, learning_rate=0.01)
+learner = MyNeuralNetwork(epochs=10, learning_rate=0.01)
 
 # train for ten epochs:
-model = fit(algorithm, data)
+model = fit(learner, data)
 
 # train for two more epochs using new data and new learning rate:
 model = update_observations(model, new_data; epochs=2, learning_rate=0.1)
 ```
 
-When following the call `fit(algorithm, data)`, the `update` call is semantically
+When following the call `fit(learner, data)`, the `update` call is semantically
 equivalent to retraining ab initio using a concatenation of `data` and `new_data`,
 *provided there are no hyperparameter replacements* (which rules out the example
-above). Behaviour is otherwise algorithm-specific.
+above). Behaviour is otherwise learner-specific.
 
 See also [`fit`](@ref), [`update`](@ref), [`update_features`](@ref).
 
@@ -139,10 +140,10 @@ Return an updated version of the `model` object returned by a previous [`fit`](@
 `update` call given the new features encapsulated in `new_data`. One may additionally
 specify hyperparameter replacements in the form `p1=value1, p2=value2, ...`.
 
-When following the call `fit(algorithm, data)`, the `update` call is semantically
+When following the call `fit(learner, data)`, the `update` call is semantically
 equivalent to retraining ab initio using a concatenation of `data` and `new_data`,
 *provided there are no hyperparameter replacements.* Behaviour is otherwise
-algorithm-specific.
+learner-specific.
 
 See also [`fit`](@ref), [`update`](@ref), [`update_features`](@ref).
 

--- a/src/obs.jl
+++ b/src/obs.jl
@@ -1,14 +1,14 @@
 """
-    obs(algorithm, data)
+    obs(learner, data)
     obs(model, data)
 
-Return an algorithm-specific representation of `data`, suitable for passing to `fit`
+Return learner-specific representation of `data`, suitable for passing to `fit`
 (first signature) or to `predict` and `transform` (second signature), in place of
-`data`. Here `model` is the return value of `fit(algorithm, ...)` for some LearnAPI.jl
-algorithm, `algorithm`.
+`data`. Here `model` is the return value of `fit(learner, ...)` for some LearnAPI.jl
+learner, `learner`.
 
 The returned object is guaranteed to implement observation access as indicated by
-[`LearnAPI.data_interface(algorithm)`](@ref), typically
+[`LearnAPI.data_interface(learner)`](@ref), typically
 [`LearnAPI.RandomAccess()`](@ref).
 
 Calling `fit`/`predict`/`transform` on the returned objects may have performance
@@ -23,18 +23,18 @@ Usual workflow, using data-specific resampling methods:
 ```julia
 data = (X, y) # a DataFrame and a vector
 data_train = (Tables.select(X, 1:100), y[1:100])
-model = fit(algorithm, data_train)
+model = fit(learner, data_train)
 ŷ = predict(model, Point(), X[101:150])
 ```
 
-Alternative workflow using `obs` and the MLUtils.jl method `getobs` (assumes
-`LearnAPI.data_interface(algorithm) == RandomAccess()`):
+Alternative, data agnostic, workflow using `obs` and the MLUtils.jl method `getobs`
+(assumes `LearnAPI.data_interface(learner) == RandomAccess()`):
 
 ```julia
 import MLUtils
 
-fit_observations = obs(algorithm, data)
-model = fit(algorithm, MLUtils.getobs(fit_observations, 1:100))
+fit_observations = obs(learner, data)
+model = fit(learner, MLUtils.getobs(fit_observations, 1:100))
 
 predict_observations = obs(model, X)
 ẑ = predict(model, Point(), MLUtils.getobs(predict_observations, 101:150))
@@ -50,15 +50,15 @@ See also [`LearnAPI.data_interface`](@ref).
 
 Implementation is typically optional.
 
-For each supported form of `data` in `fit(algorithm, data)`, it must be true that `model =
-fit(algorithm, observations)` is equivalent to `model = fit(algorithm, data)`, whenever
-`observations = obs(algorithm, data)`. For each supported form of `data` in calls
+For each supported form of `data` in `fit(learner, data)`, it must be true that `model =
+fit(learner, observations)` is equivalent to `model = fit(learner, data)`, whenever
+`observations = obs(learner, data)`. For each supported form of `data` in calls
 `predict(model, ..., data)` and `transform(model, data)`, where implemented, the calls
 `predict(model, ..., observations)` and `transform(model, observations)` are supported
 alternatives, whenever `observations = obs(model, data)`.
 
-The fallback for `obs` is `obs(model_or_algorithm, data) = data`, and the fallback for
-`LearnAPI.data_interface(algorithm)` is `LearnAPI.RandomAccess()`. For details refer to
+The fallback for `obs` is `obs(model_or_learner, data) = data`, and the fallback for
+`LearnAPI.data_interface(learner)` is `LearnAPI.RandomAccess()`. For details refer to
 the [`LearnAPI.data_interface`](@ref) document string.
 
 In particular, if the `data` to be consumed by `fit`, `predict` or `transform` consists
@@ -66,9 +66,9 @@ only of suitable tables and arrays, then `obs` and `LearnAPI.data_interface` do 
 to be overloaded. However, the user will get no performance benefits by using `obs` in
 that case.
 
-When overloading `obs(algorithm, data)` to output new model-specific representations of
+When overloading `obs(learner, data)` to output new model-specific representations of
 data, it may be necessary to also overload [`LearnAPI.features`](@ref),
-[`LearnAPI.target`](@ref) (supervised algorithms), and/or [`LearnAPI.weights`](@ref) (if
+[`LearnAPI.target`](@ref) (supervised learners), and/or [`LearnAPI.weights`](@ref) (if
 weights are supported), for extracting relevant parts of the representation.
 
 ## Sample implementation
@@ -78,4 +78,4 @@ Refer to the "Anatomy of an Implementation" section of the LearnAPI.jl
 
 
 """
-obs(algorithm_or_model, data) = data
+obs(learner_or_model, data) = data

--- a/src/predict_transform.jl
+++ b/src/predict_transform.jl
@@ -7,7 +7,7 @@ end
 DOC_MUTATION(op) =
     """
 
-    If [`LearnAPI.is_static(algorithm)`](@ref) is `true`, then `$op` may mutate it's first
+    If [`LearnAPI.is_static(learner)`](@ref) is `true`, then `$op` may mutate it's first
     argument, but not in a way that alters the result of a subsequent call to `predict`,
     `transform` or `inverse_transform`. See more at [`fit`](@ref).
 
@@ -16,9 +16,9 @@ DOC_MUTATION(op) =
 DOC_SLURPING(op) =
     """
 
-    An algorithm is free to implement `$op` signatures with additional positional
-    arguments (eg., data-slurping signatures) but LearnAPI.jl is silent about their
-    interpretation or existence.
+    An implementation is free to implement `$op` signatures with additional positional
+ arguments (eg., data-slurping signatures) but LearnAPI.jl is silent about their
+ interpretation or existence.
 
     """
 
@@ -29,7 +29,7 @@ DOC_MINIMIZE(func) =
     identity must hold:
 
     ```julia
-    $func(LearnAPI.strip(model), args...) = $func(model, args...)
+    $func(LearnAPI.strip(model), args...) == $func(model, args...)
     ```
 
     """
@@ -41,7 +41,7 @@ DOC_DATA_INTERFACE(method) =
 
     By default, it is assumed that `data` supports the [`LearnAPI.RandomAccess`](@ref)
     interface; this includes all matrices, with observations-as-columns, most tables, and
-    tuples thereof). See [`LearnAPI.RandomAccess`](@ref) for details. If this is not the
+    tuples thereof. See [`LearnAPI.RandomAccess`](@ref) for details. If this is not the
     case then an implementation must either: (i) overload [`obs`](@ref) to articulate how
     provided data can be transformed into a form that does support
     [`LearnAPI.RandomAccess`](@ref); or (ii) overload the trait
@@ -61,21 +61,21 @@ The first signature returns target predictions, or proxies for target prediction
 input features `data`, according to some `model` returned by [`fit`](@ref). Where
 supported, these are literally target predictions if `kind_of_proxy = Point()`,
 and probability density/mass functions if `kind_of_proxy = Distribution()`. List all
-options with [`LearnAPI.kinds_of_proxy(algorithm)`](@ref), where `algorithm =
-LearnAPI.algorithm(model)`.
+options with [`LearnAPI.kinds_of_proxy(learner)`](@ref), where `learner =
+LearnAPI.learner(model)`.
 
 ```julia
-model = fit(algorithm, (X, y))
+model = fit(learner, (X, y))
 predict(model, Point(), Xnew)
 ```
 
-The shortcut `predict(model, data)` calls the first method with an algorithm-specific
-`kind_of_proxy`, namely the first element of [`LearnAPI.kinds_of_proxy(algorithm)`](@ref),
+The shortcut `predict(model, data)` calls the first method with learner-specific
+`kind_of_proxy`, namely the first element of [`LearnAPI.kinds_of_proxy(learner)`](@ref),
 which lists all supported target proxies.
 
-The argument `model` is anything returned by a call of the form `fit(algorithm, ...)`.
+The argument `model` is anything returned by a call of the form `fit(learner, ...)`.
 
-If `LearnAPI.features(LearnAPI.algorithm(model)) == nothing`, then argument `data` is
+If `LearnAPI.features(LearnAPI.learner(model)) == nothing`, then the argument `data` is
 omitted in both signatures. An example is density estimators.
 
 See also [`fit`](@ref), [`transform`](@ref), [`inverse_transform`](@ref).
@@ -83,7 +83,7 @@ See also [`fit`](@ref), [`transform`](@ref), [`inverse_transform`](@ref).
 # Extended help
 
 Note `predict ` must not mutate any argument, except in the special case
-`LearnAPI.is_static(algorithm) == true`.
+`LearnAPI.is_static(learner) == true`.
 
 # New implementations
 
@@ -95,7 +95,7 @@ is implemented, but each `kind_of_proxy` that gets an implementation must be add
 list returned by [`LearnAPI.kinds_of_proxy`](@ref).
 
 If `data` is not present in the implemented signature (eg., for density estimators) then
-[`LearnAPI.features(algorithm, data)`](@ref) must return `nothing`.
+[`LearnAPI.features(learner, data)`](@ref) must return `nothing`.
 
 $(DOC_IMPLEMENTED_METHODS(":(LearnAPI.predict)"))
 
@@ -106,8 +106,8 @@ $(DOC_MUTATION(:predict))
 $(DOC_DATA_INTERFACE(:predict))
 
 """
-predict(model, data) = predict(model, kinds_of_proxy(algorithm(model)) |> first, data)
-predict(model) = predict(model, kinds_of_proxy(algorithm(model)) |> first)
+predict(model, data) = predict(model, kinds_of_proxy(learner(model)) |> first, data)
+predict(model) = predict(model, kinds_of_proxy(learner(model)) |> first)
 
 """
     transform(model, data)
@@ -119,28 +119,34 @@ Return a transformation of some `data`, using some `model`, as returned by
 
 Below, `X` and `Xnew` are data of the same form.
 
-For an `algorithm` that generalizes to new data ("learns"):
+For a `learner` that generalizes to new data ("learns"):
 
 ```julia
-model = fit(algorithm, X; verbosity=0)
+model = fit(learner, X; verbosity=0)
 transform(model, Xnew)
+```
+
+or, in one step (where supported):
+
+```julia
+W = transform(learner, X) # `fit` implied
 ```
 
 For a static (non-generalizing) transformer:
 
 ```julia
-model = fit(algorithm)
+model = fit(learner)
 W = transform(model, X)
 ```
 
 or, in one step (where supported):
 
 ```julia
-W = transform(algorithm, X)
+W = transform(learner, X) # `fit` implied
 ```
 
 Note `transform` does not mutate any argument, except in the special case
-`LearnAPI.is_static(algorithm) == true`.
+`LearnAPI.is_static(learner) == true`.
 
 See also [`fit`](@ref), [`predict`](@ref),
 [`inverse_transform`](@ref).
@@ -149,7 +155,7 @@ See also [`fit`](@ref), [`predict`](@ref),
 
 # New implementations
 
-Implementation for new LearnAPI.jl algorithms is
+Implementation for new LearnAPI.jl learners is
 optional. $(DOC_IMPLEMENTED_METHODS(":(LearnAPI.transform)"))
 
 $(DOC_SLURPING(:transform))
@@ -169,15 +175,15 @@ function transform end
 
 Inverse transform `data` according to some `model` returned by [`fit`](@ref). Here
 "inverse" is to be understood broadly, e.g, an approximate
-right inverse for [`transform`](@ref).
+right or left inverse for [`transform`](@ref).
 
 # Example
 
-In the following, `algorithm` is some dimension-reducing algorithm that generalizes to new
+In the following, `learner` is some dimension-reducing algorithm that generalizes to new
 data (such as PCA); `Xtrain` is the training input and `Xnew` the input to be reduced:
 
 ```julia
-model = fit(algorithm, Xtrain)
+model = fit(learner, Xtrain)
 W = transform(model, Xnew)       # reduced version of `Xnew`
 Ŵ = inverse_transform(model, W)  # embedding of `W` in original space
 ```

--- a/src/predict_transform.jl
+++ b/src/predict_transform.jl
@@ -45,7 +45,7 @@ DOC_DATA_INTERFACE(method) =
     case then an implementation must either: (i) overload [`obs`](@ref) to articulate how
     provided data can be transformed into a form that does support
     [`LearnAPI.RandomAccess`](@ref); or (ii) overload the trait
-    [`LearnAPI.data_interface`](@ref) to specify a more relaxed data API. Refer to
+    [`LearnAPI.data_interface`](@ref) to specify a more relaxed data API. Refer tbo
     document strings for details.
 
     """
@@ -91,8 +91,10 @@ If there is no notion of a "target" variable in the LearnAPI.jl sense, or you ne
 operation with an inverse, implement [`transform`](@ref) instead.
 
 Implementation is optional. Only the first signature (with or without the `data` argument)
-is implemented, but each `kind_of_proxy` that gets an implementation must be added to the
-list returned by [`LearnAPI.kinds_of_proxy`](@ref).
+is implemented, but each `kind_of_proxy::`[`KindOfProxy`](@ref) that gets an
+implementation must be added to the list returned by
+[`LearnAPI.kinds_of_proxy(learner)`](@ref). List all available kinds of proxy by doing
+`LearnAPI.kinds_of_proxy()`.
 
 If `data` is not present in the implemented signature (eg., for density estimators) then
 [`LearnAPI.features(learner, data)`](@ref) must return `nothing`.

--- a/src/target_weights_features.jl
+++ b/src/target_weights_features.jl
@@ -1,9 +1,9 @@
 """
-    LearnAPI.target(algorithm, data) -> target
+    LearnAPI.target(learner, data) -> target
 
-Return, for each form of `data` supported in a call of the form [`fit(algorithm,
+Return, for each form of `data` supported in a call of the form [`fit(learner,
 data)`](@ref), the target variable part of `data`. If `nothing` is returned, the
-`algorithm` does not see a target variable in training (is unsupervised).
+`learner` does not see a target variable in training (is unsupervised).
 
 Refer to LearnAPI.jl documentation for the precise meaning of "target".
 
@@ -18,9 +18,9 @@ $(DOC_IMPLEMENTED_METHODS(":(LearnAPI.target)"; overloaded=true))
 target(::Any, data) = nothing
 
 """
-    LearnAPI.weights(algorithm, data) -> weights
+    LearnAPI.weights(learner, data) -> weights
 
-Return, for each form of `data` supported in a call of the form [`fit(algorithm,
+Return, for each form of `data` supported in a call of the form [`fit(learner,
 data)`](@ref), the per-observation weights part of `data`. Where `nothing` is returned, no
 weights are part of `data`, which is to be interpreted as uniform weighting.
 
@@ -34,9 +34,9 @@ $(DOC_IMPLEMENTED_METHODS(":(LearnAPI.weights)"; overloaded=true))
 weights(::Any, data) = nothing
 
 """
-    LearnAPI.features(algorithm, data)
+    LearnAPI.features(learner, data)
 
-Return, for each form of `data` supported in a call of the form [`fit(algorithm,
+Return, for each form of `data` supported in a call of the form [`fit(learner,
 data)`](@ref), the "features" part of `data` (as opposed to the target
 variable, for example).
 
@@ -44,14 +44,14 @@ The returned object `X` may always be passed to `predict` or `transform`, where
 implemented, as in the following sample workflow:
 
 ```julia
-model = fit(algorithm, data)
+model = fit(learner, data)
 X = features(data)
-ŷ = predict(algorithm, kind_of_proxy, X) # eg, `kind_of_proxy = Point()`
+ŷ = predict(learner, kind_of_proxy, X) # eg, `kind_of_proxy = Point()`
 ```
 
 The returned object has the same number of observations as `data`. For supervised models
-(i.e., where `:(LearnAPI.target) in LearnAPI.functions(algorithm)`) `ŷ` above is generally
-intended to be an approximate proxy for `LearnAPI.target(algorithm, data)`, the training
+(i.e., where `:(LearnAPI.target) in LearnAPI.functions(learner)`) `ŷ` above is generally
+intended to be an approximate proxy for `LearnAPI.target(learner, data)`, the training
 target.
 
 
@@ -61,13 +61,13 @@ That the output can be passed to `predict` and/or `transform`, and has the same 
 observations as `data`, are the only contracts. A fallback returns `first(data)` if `data`
 is a tuple, and otherwise returns `data`.
 
-Overloading may be necessary if [`obs(algorithm, data)`](@ref) is overloaded to return
-some algorithm-specific representation of training `data`. For density estimators, whose
+Overloading may be necessary if [`obs(learner, data)`](@ref) is overloaded to return
+some learner-specific representation of training `data`. For density estimators, whose
 `fit` typically consumes *only* a target variable, you should overload this method to
 return `nothing`.
 
 """
-features(algorithm, data) = _first(data)
+features(learner, data) = _first(data)
 _first(data) = data
 _first(data::Tuple) = first(data)
 # note the factoring above guards against method ambiguities

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -9,9 +9,9 @@ function name_value_pair(ex)
 end
 
 """
-    @trait(TypeEx, trait1=value1, trait2=value2, ...)
+    @trait(LearnerType, trait1=value1, trait2=value2, ...)
 
-Overload a number of traits for algorithms of type `TypeEx`. For example, the code
+Overload a number of traits for learners of type `LearnerType`. For example, the code
 
 ```julia
 @trait(
@@ -29,13 +29,13 @@ LearnAPI.doc_url(::RidgeRegressor) = "https://some.cool.documentation",
 ```
 
 """
-macro trait(algorithm_ex, exs...)
+macro trait(learner_ex, exs...)
     program = quote end
     for ex in exs
         trait_ex, value_ex = name_value_pair(ex)
         push!(
             program.args,
-            :($LearnAPI.$trait_ex(::$algorithm_ex) = $value_ex),
+            :($LearnAPI.$trait_ex(::$learner_ex) = $value_ex),
         )
     end
     return esc(program)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -135,9 +135,8 @@ See also [`LearnAPI.predict`](@ref), [`LearnAPI.KindOfProxy`](@ref).
 
 Must be overloaded whenever `predict` is implemented.
 
-Elements of the returned tuple must be instances of types in the return value of
-`LearnAPI.kinds_of_proxy()`, i.e., one of the following, described further in LearnAPI.jl
-documentation: $CONCRETE_TARGET_PROXY_TYPES_LIST.
+Elements of the returned tuple must be instances of [`LearnAPI.KindOfProxy`](@ref). List
+all possibilities by running `LearnAPI.kinds_of_proxy()`.
 
 Suppose, for example, we have the following implementation of a supervised learner
 returning only probabilistic predictions:
@@ -158,7 +157,12 @@ For more on target variables and target proxies, refer to the LearnAPI documenta
 
 """
 kinds_of_proxy(::Any) = ()
-kinds_of_proxy() = CONCRETE_TARGET_PROXY_TYPES
+kinds_of_proxy() = map(CONCRETE_TARGET_PROXY_SYMBOLS) do ex
+    quote
+        $ex()
+    end |> eval
+end
+
 
 
 tags() = [

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,17 +1,17 @@
 # There are two types of traits - ordinary traits that an implementation overloads to make
-# promises of algorithm behavior, and derived traits, which are never overloaded.
+# promises of learner behavior, and derived traits, which are never overloaded.
 
 const DOC_UNKNOWN =
-    "Returns `\"unknown\"` if the algorithm implementation has "*
+    "Returns `\"unknown\"` if the learner implementation has "*
     "not overloaded the trait. "
-const DOC_ON_TYPE = "The value of the trait must depend only on the type of `algorithm`. "
+const DOC_ON_TYPE = "The value of the trait must depend only on the type of `learner`. "
 
 const DOC_EXPLAIN_EACHOBS =
     """
 
     Here, "for each `o` in `observations`" is understood in the sense of
-    [`LearnAPI.data_interface(algorithm)`](@ref). For example, if
-    `LearnAPI.data_interface(algorithm) == Base.HasLength()`, then this means "for `o` in
+    [`LearnAPI.data_interface(learner)`](@ref). For example, if
+    `LearnAPI.data_interface(learner) == Base.HasLength()`, then this means "for `o` in
     `MLUtils.eachobs(observations)`".
 
     """
@@ -19,16 +19,16 @@ const DOC_EXPLAIN_EACHOBS =
 # # OVERLOADABLE TRAITS
 
 """
-    Learn.API.constructor(algorithm)
+    Learn.API.constructor(learner)
 
-Return a keyword constructor that can be used to clone `algorithm`:
+Return a keyword constructor that can be used to clone `learner`:
 
 ```julia-repl
-julia> algorithm.lambda
+julia> learner.lambda
 0.1
-julia> C = LearnAPI.constructor(algorithm)
-julia> algorithm2 = C(lambda=0.2)
-julia> algorithm2.lambda
+julia> C = LearnAPI.constructor(learner)
+julia> learner2 = C(lambda=0.2)
+julia> learner2.lambda
 0.2
 ```
 
@@ -36,21 +36,21 @@ julia> algorithm2.lambda
 
 All new implementations must overload this trait.
 
-Attach public LearnAPI.jl-related documentation for an algorithm to the constructor, not
-the algorithm struct.
+Attach public LearnAPI.jl-related documentation for learner to the constructor, not
+the learner struct.
 
-It must be possible to recover an algorithm from the constructor returned as follows:
+It must be possible to recover learner from the constructor returned as follows:
 
 ```julia
-properties = propertynames(algorithm)
-named_properties = NamedTuple{properties}(getproperty.(Ref(algorithm), properties))
-@assert algorithm == LearnAPI.constructor(algorithm)(; named_properties...)
+properties = propertynames(learner)
+named_properties = NamedTuple{properties}(getproperty.(Ref(learner), properties))
+@assert learner == LearnAPI.constructor(learner)(; named_properties...)
 ```
 
-which can be tested with `@assert LearnAPI.clone(algorithm) == algorithm`.
+which can be tested with `@assert LearnAPI.clone(learner) == learner`.
 
 The keyword constructor provided by `LearnAPI.constructor` must provide default values for
-all properties, with the exception of those that can take other LearnAPI.jl algorithms as
+all properties, with the exception of those that can take other LearnAPI.jl learners as
 values. These can be provided with the default `nothing`, with the constructor throwing an
 error if the default value persists.
 
@@ -58,17 +58,17 @@ error if the default value persists.
 function constructor end
 
 """
-    LearnAPI.functions(algorithm)
+    LearnAPI.functions(learner)
 
 Return a tuple of expressions representing functions that can be meaningfully applied
-with `algorithm`, or an associated model (object returned by `fit(algorithm, ...)`, as the
-first argument. Algorithm traits (methods for which `algorithm` is the *only* argument)
+with `learner`, or an associated model (object returned by `fit(learner, ...)`, as the
+first argument. Learner traits (methods for which `learner` is the *only* argument)
 are excluded.
 
 The returned tuple may include expressions like `:(DecisionTree.print_tree)`, which
 reference functions not owned by LearnAPI.jl.
 
-The understanding is that `algorithm` is a LearnAPI-compliant object whenever the return
+The understanding is that `learner` is a LearnAPI-compliant object whenever the return
 value is non-empty.
 
 # Extended help
@@ -81,7 +81,7 @@ return value:
 | expression                        | implementation compulsory? | include in returned tuple?         |
 |-----------------------------------|----------------------------|------------------------------------|
 | `:(LearnAPI.fit)`                 | yes                        | yes                                |
-| `:(LearnAPI.algorithm)`           | yes                        | yes                                |
+| `:(LearnAPI.learner)`           | yes                        | yes                                |
 | `:(LearnAPI.strip)`               | no                         | yes                                |
 | `:(LearnAPI.obs)`                 | no                         | yes                                |
 | `:(LearnAPI.features)`            | no                         | yes, unless `fit` consumes no data |
@@ -96,13 +96,13 @@ return value:
 | < accessor functions>             | no                         | only if implemented                |
 
 Also include any implemented accessor functions, both those owned by LearnaAPI.jl, and any
-algorithm-specific ones. The LearnAPI.jl accessor functions are: $ACCESSOR_FUNCTIONS_LIST
+learner-specific ones. The LearnAPI.jl accessor functions are: $ACCESSOR_FUNCTIONS_LIST
 (`LearnAPI.strip` is always included).
 
 """
 functions() = (
     :(LearnAPI.fit),
-    :(LearnAPI.algorithm),
+    :(LearnAPI.learner),
     :(LearnAPI.strip),
     :(LearnAPI.obs),
     :(LearnAPI.features),
@@ -117,9 +117,9 @@ functions() = (
 )
 
 """
-    LearnAPI.kinds_of_proxy(algorithm)
+    LearnAPI.kinds_of_proxy(learner)
 
-Returns a tuple of all instances, `kind`, for which for which `predict(algorithm, kind,
+Returns a tuple of all instances, `kind`, for which for which `predict(learner, kind,
 data...)` has a guaranteed implementation. Each such `kind` subtypes
 [`LearnAPI.KindOfProxy`](@ref). Examples are `Point()` (for predicting actual
 target values) and `Distributions()` (for predicting probability mass/density functions).
@@ -143,13 +143,13 @@ Suppose, for example, we have the following implementation of a supervised learn
 returning only probabilistic predictions:
 
 ```julia
-LearnAPI.predict(algorithm::MyNewAlgorithmType, LearnAPI.Distribution(), Xnew) = ...
+LearnAPI.predict(learner::MyNewLearnerType, LearnAPI.Distribution(), Xnew) = ...
 ```
 
 Then we can declare
 
 ```julia
-@trait MyNewAlgorithmType kinds_of_proxy = (LearnaAPI.Distribution(),)
+@trait MyNewLearnerType kinds_of_proxy = (LearnaAPI.Distribution(),)
 ```
 
 LearnAPI.jl provides the fallback for `predict(model, data)`.
@@ -166,7 +166,7 @@ tags() = [
     "classification",
     "clustering",
     "gradient descent",
-    "iterative algorithms",
+    "iterative learners",
     "incremental algorithms",
     "feature engineering",
     "dimension reduction",
@@ -189,9 +189,9 @@ tags() = [
 ]
 
 """
-    LearnAPI.tags(algorithm)
+    LearnAPI.tags(learner)
 
-Lists one or more suggestive algorithm tags. Do `LearnAPI.tags()` to list
+Lists one or more suggestive learner tags. Do `LearnAPI.tags()` to list
 all possible.
 
 !!! warning
@@ -206,9 +206,9 @@ This trait should return a tuple of strings, as in `("classifier", "text analysi
 tags(::Any) = ()
 
 """
-    LearnAPI.is_pure_julia(algorithm)
+    LearnAPI.is_pure_julia(learner)
 
-Returns `true` if training `algorithm` requires evaluation of pure Julia code only.
+Returns `true` if training `learner` requires evaluation of pure Julia code only.
 
 # New implementations
 
@@ -218,10 +218,10 @@ The fallback is `false`.
 is_pure_julia(::Any) = false
 
 """
-    LearnAPI.pkg_name(algorithm)
+    LearnAPI.pkg_name(learner)
 
 Return the name of the package module which supplies the core training algorithm for
-`algorithm`.  This is not necessarily the package providing the LearnAPI
+`learner`.  This is not necessarily the package providing the LearnAPI
 interface.
 
 $DOC_UNKNOWN
@@ -234,18 +234,18 @@ Must return a string, as in `"DecisionTree"`.
 pkg_name(::Any) = "unknown"
 
 """
-    LearnAPI.pkg_license(algorithm)
+    LearnAPI.pkg_license(learner)
 
 Return the name of the software license, such as `"MIT"`, applying to the package where the
-core algorithm for `algorithm` is implemented.
+core algorithm for `learner` is implemented.
 
 """
 pkg_license(::Any) = "unknown"
 
 """
-    LearnAPI.doc_url(algorithm)
+    LearnAPI.doc_url(learner)
 
-Return a url where the core algorithm for `algorithm` is documented.
+Return a url where the core algorithm for `learner` is documented.
 
 $DOC_UNKNOWN
 
@@ -257,11 +257,11 @@ Must return a string, such as `"https://en.wikipedia.org/wiki/Decision_tree_lear
 doc_url(::Any) = "unknown"
 
 """
-    LearnAPI.load_path(algorithm)
+    LearnAPI.load_path(learner)
 
-Return a string indicating where in code the definition of the algorithm's constructor can
+Return a string indicating where in code the definition of the learner's constructor can
 be found, beginning with the name of the package module defining it. By "constructor" we
-mean the return value of [`LearnAPI.constructor(algorithm)`](@ref).
+mean the return value of [`LearnAPI.constructor(learner)`](@ref).
 
 # Implementation
 
@@ -271,7 +271,7 @@ following julia code will not error:
 ```julia
 import FastTrees
 import LearnAPI
-@assert FastTrees.LearnAPI.DecisionTreeClassifier == LearnAPI.constructor(algorithm)
+@assert FastTrees.LearnAPI.DecisionTreeClassifier == LearnAPI.constructor(learner)
 ```
 
 $DOC_UNKNOWN
@@ -282,18 +282,18 @@ load_path(::Any) = "unknown"
 
 
 """
-    LearnAPI.is_composite(algorithm)
+    LearnAPI.is_composite(learner)
 
-Returns `true` if one or more properties (fields) of `algorithm` may themselves be
-algorithms, and `false` otherwise.
+Returns `true` if one or more properties (fields) of `learner` may themselves be
+learners, and `false` otherwise.
 
 See also [`LearnAPI.components`](@ref).
 
 # New implementations
 
-This trait should be overloaded if one or more properties (fields) of `algorithm` may take
-algorithm values. Fallback return value is `false`. The keyword constructor for such an
-algorithm need not prescribe defaults for algorithm-valued properties. Implementation of
+This trait should be overloaded if one or more properties (fields) of `learner` may take
+learner values. Fallback return value is `false`. The keyword constructor for such an
+learner need not prescribe defaults for learner-valued properties. Implementation of
 the accessor function [`LearnAPI.components`](@ref) is recommended.
 
 $DOC_ON_TYPE
@@ -303,9 +303,9 @@ $DOC_ON_TYPE
 is_composite(::Any) = false
 
 """
-    LearnAPI.human_name(algorithm)
+    LearnAPI.human_name(learner)
 
-Return a human-readable string representation of `typeof(algorithm)`. Primarily intended
+Return a human-readable string representation of `typeof(learner)`. Primarily intended
 for auto-generation of documentation.
 
 # New implementations
@@ -316,14 +316,14 @@ to return `"K-nearest neighbors regressor"`. Ideally, this is a "concrete" noun 
 `"ridge regressor"` rather than an "abstract" noun like `"ridge regression"`.
 
 """
-human_name(algorithm) = snakecase(name(algorithm), delim=' ') # `name` defined below
+human_name(learner) = snakecase(name(learner), delim=' ') # `name` defined below
 
 """
-    LearnAPI.data_interface(algorithm)
+    LearnAPI.data_interface(learner)
 
-Return the data interface supported by `algorithm` for accessing individual observations
-in representations of input data returned by [`obs(algorithm, data)`](@ref) or
-[`obs(model, data)`](@ref), whenever `algorithm == LearnAPI.algorithm(model)`. Here `data`
+Return the data interface supported by `learner` for accessing individual observations
+in representations of input data returned by [`obs(learner, data)`](@ref) or
+[`obs(model, data)`](@ref), whenever `learner == LearnAPI.learner(model)`. Here `data`
 is `fit`, `predict`, or `transform`-consumable data.
 
 Possible return values are [`LearnAPI.RandomAccess`](@ref),
@@ -340,17 +340,17 @@ tables, and tuples of these. See the doc-string for details.
 data_interface(::Any) = LearnAPI.RandomAccess()
 
 """
-    LearnAPI.is_static(algorithm)
+    LearnAPI.is_static(learner)
 
 Returns `true` if [`fit`](@ref) is called with no data arguments, as in
-`fit(algorithm)`. That is, `algorithm` does not generalize to new data, and data is only
+`fit(learner)`. That is, `learner` does not generalize to new data, and data is only
 provided at the `predict` or `transform` step.
 
 For example, some clustering algorithms are applied with this workflow, to assign labels
 to the observations in `X`:
 
 ```julia
-model = fit(algorithm) # no training data
+model = fit(learner) # no training data
 labels = predict(model, X) # may mutate `model`!
 
 # extract some byproducts of the clustering algorithm (e.g., outliers):
@@ -366,9 +366,9 @@ arguments. See more at [`fit`](@ref).
 is_static(::Any) = false
 
 """
-    LearnAPI.iteration_parameter(algorithm)
+    LearnAPI.iteration_parameter(learner)
 
-The name of the iteration parameter of `algorithm`, or `nothing` if the algorithm is not
+The name of the iteration parameter of `learner`, or `nothing` if the algorithm is not
 iterative.
 
 # New implementations
@@ -380,12 +380,12 @@ iteration_parameter(::Any) = nothing
 
 
 """
-    LearnAPI.fit_observation_scitype(algorithm)
+    LearnAPI.fit_observation_scitype(learner)
 
 Return an upper bound `S` on the scitype of individual observations guaranteed to work
-when calling `fit`: if `observations = obs(algorithm, data)` and
+when calling `fit`: if `observations = obs(learner, data)` and
 `ScientificTypes.scitype(o) <:S` for each `o` in `observations`, then the call
-`fit(algorithm, data)` is supported.
+`fit(learner, data)` is supported.
 
 $DOC_EXPLAIN_EACHOBS
 
@@ -399,14 +399,14 @@ Optional. The fallback return value is `Union{}`.
 fit_observation_scitype(::Any) = Union{}
 
 """
-    LearnAPI.target_observation_scitype(algorithm)
+    LearnAPI.target_observation_scitype(learner)
 
 Return an upper bound `S` on the scitype of each observation of an applicable target
 variable. Specifically:
 
-- If `:(LearnAPI.target) in LearnAPI.functions(algorithm)` (i.e., `fit` consumes target
-  variables) then "target" means anything returned by `LearnAPI.target(algorithm, data)`,
-  where `data` is an admissible argument in the call `fit(algorithm, data)`.
+- If `:(LearnAPI.target) in LearnAPI.functions(learner)` (i.e., `fit` consumes target
+  variables) then "target" means anything returned by `LearnAPI.target(learner, data)`,
+  where `data` is an admissible argument in the call `fit(learner, data)`.
 
 - `S` will always be an upper bound on the scitype of (point) observations that could be
   conceivably extracted from the output of [`predict`](@ref).
@@ -414,7 +414,7 @@ variable. Specifically:
 To illustate the second case, suppose we have
 
 ```julia
-model = fit(algorithm, data)
+model = fit(learner, data)
 ŷ = predict(model, Sampleable(), data_new)
 ```
 
@@ -433,8 +433,8 @@ target_observation_scitype(::Any) = Any
 
 # # DERIVED TRAITS
 
-name(algorithm) = split(string(constructor(algorithm)), ".") |> last
-is_algorithm(algorithm) = !isempty(functions(algorithm))
-preferred_kind_of_proxy(algorithm) = first(kinds_of_proxy(algorithm))
-target(algorithm) = :(LearnAPI.target) in functions(algorithm)
-weights(algorithm) = :(LearnAPI.weights) in functions(algorithm)
+name(learner) = split(string(constructor(learner)), ".") |> last
+is_learner(learner) = !isempty(functions(learner))
+preferred_kind_of_proxy(learner) = first(kinds_of_proxy(learner))
+target(learner) = :(LearnAPI.target) in functions(learner)
+weights(learner) = :(LearnAPI.weights) in functions(learner)

--- a/src/types.jl
+++ b/src/types.jl
@@ -99,11 +99,11 @@ struct JointLogDistribution <: Joint end
 """
     Single <: KindOfProxy
 
-Abstract subtype of [`LearnAPI.KindOfProxy`](@ref). It applies only to algorithms for
+Abstract subtype of [`LearnAPI.KindOfProxy`](@ref). It applies only to learners for
 which `predict` has no data argument, i.e., is of the form `predict(model,
 kind_of_proxy)`. An example is an algorithm learning a probability distribution from
 samples, and we regard the samples as drawn from the "target" variable. If in this case,
-`kind_of_proxy` is an instance of `LearnAPI.Single` then, `predict(algorithm)` returns a
+`kind_of_proxy` is an instance of `LearnAPI.Single` then, `predict(learner)` returns a
 single object representing a probability distribution.
 
 | type `T`                         | form of output of `predict(model, ::T)`                                |
@@ -146,14 +146,14 @@ const DOC_HOW_TO_LIST_PROXIES =
     LearnAPI.KindOfProxy
 
 Abstract type whose concrete subtypes `T` each represent a different kind of proxy for
-some target variable, associated with some algorithm. Instances `T()` are used to request
+some target variable, associated with some learner. Instances `T()` are used to request
 the form of target predictions in [`predict`](@ref) calls.
 
 See LearnAPI.jl documentation for an explanation of "targets" and "target proxies".
 
 For example, `Distribution` is a concrete subtype of `LearnAPI.KindOfProxy` and a call
 like `predict(model, Distribution(), Xnew)` returns a data object whose observations are
-probability density/mass functions, assuming `algorithm` supports predictions of that
+probability density/mass functions, assuming `learner` supports predictions of that
 form.
 
 $DOC_HOW_TO_LIST_PROXIES
@@ -180,15 +180,15 @@ All arrays implement `RandomAccess`, with the last index being the observation i
 (observations-as-columns in matrices).
 
 A Tables.jl compatible table `data` implements `RandomAccess` if `Tables.istable(data)` is
-true and if `data` implements `DataAPI.nrows`. This includes many tables, and in
+true and if `data` implements `DataAPI.nrow`. This includes many tables, and in
 particular, `DataFrame`s. Tables that are also tuples are explicitly excluded.
 
 Any tuple of objects implementing `RandomAccess` also implements `RandomAccess`.
 
-If [`LearnAPI.data_interface(algorithm)`](@ref) takes the value `RandomAccess()`, then
-[`obs`](@ref)`(algorithm, ...)` is guaranteed to return objects implementing the
+If [`LearnAPI.data_interface(learner)`](@ref) takes the value `RandomAccess()`, then
+[`obs`](@ref)`(learner, ...)` is guaranteed to return objects implementing the
 `RandomAccess` interface, and the same holds for `obs(model, ...)`, whenever
-`LearnAPI.algorithm(model) == algorithm`.
+`LearnAPI.learner(model) == learner`.
 
 # Implementing `RandomAccess` for new data types
 
@@ -211,10 +211,10 @@ it implements Julia's `iterate` interface, including `Base.length`, and if
 
 - `data isa MLUtils.DataLoader`, which includes output from `MLUtils.eachobs`.
 
-If [`LearnAPI.data_interface(algorithm)`](@ref) takes the value `FiniteIterable()`, then
-[`obs`](@ref)`(algorithm, ...)` is guaranteed to return objects implementing the
+If [`LearnAPI.data_interface(learner)`](@ref) takes the value `FiniteIterable()`, then
+[`obs`](@ref)`(learner, ...)` is guaranteed to return objects implementing the
 `FiniteIterable` interface, and the same holds for `obs(model, ...)`, whenever
-`LearnAPI.algorithm(model) == algorithm`.
+`LearnAPI.learner(model) == learner`.
 
 See also [`LearnAPI.RandomAccess`](@ref), [`LearnAPI.Iterable`](@ref).
 """
@@ -227,10 +227,10 @@ A data interface type. We say that `data` implements the `Iterable` interface if
 implements Julia's basic `iterate` interface. (Such objects may not implement
 `MLUtils.numobs` or `Base.length`.)
 
-If [`LearnAPI.data_interface(algorithm)`](@ref) takes the value `Iterable()`, then
-[`obs`](@ref)`(algorithm, ...)` is guaranteed to return objects implementing `Iterable`,
-and the same holds for `obs(model, ...)`, whenever `LearnAPI.algorithm(model) ==
-algorithm`.
+If [`LearnAPI.data_interface(learner)`](@ref) takes the value `Iterable()`, then
+[`obs`](@ref)`(learner, ...)` is guaranteed to return objects implementing `Iterable`,
+and the same holds for `obs(model, ...)`, whenever `LearnAPI.learner(model) ==
+learner`.
 
 See also [`LearnAPI.FiniteIterable`](@ref), [`LearnAPI.RandomAccess`](@ref).
 

--- a/test/patterns/incremental_algorithms.jl
+++ b/test/patterns/incremental_algorithms.jl
@@ -15,7 +15,7 @@ import Distributions
 """
     NormalEstimator()
 
-Instantiate an algorithm for finding the maximum likelihood normal distribution fitting
+Instantiate a learner for finding the maximum likelihood normal distribution fitting
 some real univariate data `y`. Estimates can be updated with new data.
 
 ```julia
@@ -46,7 +46,7 @@ struct NormalEstimatorFitted{T}
     n::Int
 end
 
-LearnAPI.algorithm(::NormalEstimatorFitted) = NormalEstimator()
+LearnAPI.learner(::NormalEstimatorFitted) = NormalEstimator()
 
 function LearnAPI.fit(::NormalEstimator, y)
     n = length(y)
@@ -94,7 +94,7 @@ LearnAPI.extras(model::NormalEstimatorFitted) = (μ=model.ȳ, σ=sqrt(model.ss/
     human_name = "normal distribution estimator",
     functions = (
         :(LearnAPI.fit),
-        :(LearnAPI.algorithm),
+        :(LearnAPI.learner),
         :(LearnAPI.strip),
         :(LearnAPI.obs),
         :(LearnAPI.features),
@@ -111,8 +111,8 @@ LearnAPI.extras(model::NormalEstimatorFitted) = (μ=model.ȳ, σ=sqrt(model.ss/
     rng = StableRNG(123)
     y = rand(rng, 50);
     ynew = rand(rng, 10);
-    algorithm = NormalEstimator()
-    model = fit(algorithm, y)
+    learner = NormalEstimator()
+    model = fit(learner, y)
     d = predict(model)
     μ, σ = Distributions.params(d)
     @test μ ≈ mean(y)
@@ -122,14 +122,14 @@ LearnAPI.extras(model::NormalEstimatorFitted) = (μ=model.ȳ, σ=sqrt(model.ss/
     @test LearnAPI.extras(model) == (; μ, σ)
 
     # one-liner:
-    @test predict(algorithm, y) == d
-    @test predict(algorithm, Point(), y) ≈ μ
-    @test predict(algorithm, ConfidenceInterval(), y)[1] ≈ quantile(d, 0.025)
+    @test predict(learner, y) == d
+    @test predict(learner, Point(), y) ≈ μ
+    @test predict(learner, ConfidenceInterval(), y)[1] ≈ quantile(d, 0.025)
 
     # updating:
     model = update_observations(model, ynew)
     μ2, σ2 = LearnAPI.extras(model)
-    μ3, σ3 = LearnAPI.extras(fit(algorithm, vcat(y, ynew))) # training ab initio
+    μ3, σ3 = LearnAPI.extras(fit(learner, vcat(y, ynew))) # training ab initio
     @test μ2 ≈ μ3
     @test σ2 ≈ σ3
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -48,9 +48,11 @@ small = SmallLearner()
 
 # DERIVED TRAITS
 
+@trait SmallLearner kinds_of_proxy=(Point(),)
 @test LearnAPI.is_learner(small)
 @test !LearnAPI.target(small)
 @test !LearnAPI.weights(small)
+@test LearnAPI.preferred_kind_of_proxy(small) == Point()
 
 module FruitSalad
 import LearnAPI

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,18 +1,18 @@
 using Test
 using LearnAPI
 
-# A MINIMUM IMPLEMENTATION OF AN ALGORITHM
+# A MINIMUM IMPLEMENTATION OF A LEARNER
 
 # does nothing useful
-struct SmallAlgorithm end
-LearnAPI.fit(algorithm::SmallAlgorithm, data; verbosity=1) = algorithm
-LearnAPI.algorithm(model::SmallAlgorithm) = model
+struct SmallLearner end
+LearnAPI.fit(learner::SmallLearner, data; verbosity=1) = learner
+LearnAPI.learner(model::SmallLearner) = model
 @trait(
-    SmallAlgorithm,
-    constructor = SmallAlgorithm,
+    SmallLearner,
+    constructor = SmallLearner,
     functions = (
         :(LearnAPI.fit),
-        :(LearnAPI.algorithm),
+        :(LearnAPI.learner),
         :(LearnAPI.strip),
         :(LearnAPI.obs),
         :(LearnAPI.features),
@@ -28,9 +28,9 @@ LearnAPI.algorithm(model::SmallAlgorithm) = model
 
 # OVERLOADABLE TRAITS
 
-small = SmallAlgorithm()
-@test LearnAPI.constructor(small) == SmallAlgorithm
-@test :(LearnAPI.algorithm) in LearnAPI.functions(small)
+small = SmallLearner()
+@test LearnAPI.constructor(small) == SmallLearner
+@test :(LearnAPI.learner) in LearnAPI.functions(small)
 @test isempty(LearnAPI.kinds_of_proxy(small))
 @test isempty(LearnAPI.tags(small))
 @test !LearnAPI.is_pure_julia(small)
@@ -39,7 +39,7 @@ small = SmallAlgorithm()
 @test LearnAPI.doc_url(small) == "unknown"
 @test LearnAPI.load_path(small) == "unknown"
 @test !LearnAPI.is_composite(small)
-@test LearnAPI.human_name(small) == "small algorithm"
+@test LearnAPI.human_name(small) == "small learner"
 @test isnothing(LearnAPI.iteration_parameter(small))
 @test LearnAPI.data_interface(small) == LearnAPI.RandomAccess()
 @test !(6 isa LearnAPI.fit_observation_scitype(small))
@@ -48,7 +48,7 @@ small = SmallAlgorithm()
 
 # DERIVED TRAITS
 
-@test LearnAPI.is_algorithm(small)
+@test LearnAPI.is_learner(small)
 @test !LearnAPI.target(small)
 @test !LearnAPI.weights(small)
 

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -23,7 +23,7 @@ LearnAPI.learner(model::SmallLearner) = model
 # ZERO ARGUMENT METHODS
 
 @test :(LearnAPI.fit) in LearnAPI.functions()
-@test Point in LearnAPI.kinds_of_proxy()
+@test Point() in LearnAPI.kinds_of_proxy()
 @test "regression" in LearnAPI.tags()
 
 # OVERLOADABLE TRAITS


### PR DESCRIPTION
Doesn't change the actual API, just how we refer to the configuration objects. In a vote on [Julia discourse thread](https://discourse.julialang.org/t/ann-learnapi-jl-proposal-for-a-basement-level-machine-learning-api/93048) "learner" was voted most popular name for this.

