### PR TITLE
Fix an incorrect claim in the `FiniteIterable` doc-string

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LearnAPI"
 uuid = "92ad9a40-7767-427a-9ee6-6e577f1266cb"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1.10"

--- a/src/types.jl
+++ b/src/types.jl
@@ -244,14 +244,10 @@ struct RandomAccess <: Finite end
 """
     LearnAPI.FiniteIterable
 
-A data interface type.  We say that `data` implements the `FiniteIterable` interface if
-it implements Julia's `iterate` interface, including `Base.length`, and if
-`Base.IteratorSize(typeof(data)) == Base.HasLength()`. For example, this is true if:
-
-- `data` implements the [`LearnAPI.RandomAccess`](@ref) interface (arrays and most
-  tables); or
-
-- `data isa MLCore.DataLoader`, which includes output from `MLCore.eachobs`.
+A data interface type.  We say that `data` implements the `FiniteIterable` interface if it
+implements Julia's `iterate` interface, including `Base.length`, and if
+`Base.IteratorSize(typeof(data)) == Base.HasLength()`. For example, this is true if `data
+isa MLCore.DataLoader`, which includes the output of `MLUtils.eachobs`.
 
 If [`LearnAPI.data_interface(learner)`](@ref) takes the value `FiniteIterable()`, then
 [`obs`](@ref)`(learner, ...)` is guaranteed to return objects implementing the


### PR DESCRIPTION
If data implements `RandomAccess` it may not implement `FiniteIterable` because you also need `Base.IteratorSize(data) = HasLength()`. This contradicts an assertion in the `FiniteIterable` doc-string fixed in this PR.