### PR TITLE
Update warning about RNG hyperparameter copies

### DIFF
--- a/docs/src/predict_transform.md
+++ b/docs/src/predict_transform.md
@@ -23,7 +23,7 @@ The above signatures apply in the case that [`LearnAPI.kind_of(learner)`](@ref)
 returns  [`LearnAPI.Generative()`](@ref), as in [density
 estimation](@ref density_estimation).
 
-## [Typical worklows](@id predict_workflow)
+## [Typical workflows](@id predict_workflow)
 
 Train some supervised `learner`:
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -104,8 +104,10 @@ generally requires overloading `Base.==` for the struct.
 !!! important
 
 	No LearnAPI.jl method is permitted to mutate a learner. In particular, one should make
-	deep copies of RNG hyperparameters before using them in an implementation of
-	[`fit`](@ref).
+	copies of RNG hyperparameters before using them in an implementation of
+	[`fit`](@ref). (Do not make *deep* copies as this leads to wrong behavior in the case
+	of `Random.default_rng()`, which not an actual RNG but only a pointer to the task-local
+	default RNG.)
 
 
 #### Kinds of learner


### PR DESCRIPTION
Clarify that deep copies of RNG hyperparameters should not be made.